### PR TITLE
Responsive layout

### DIFF
--- a/map.js
+++ b/map.js
@@ -30,16 +30,15 @@ var rankColorsIndex = 0;
 
 // Responsive worldmap
 var ratio = 1000/485;
-var worldmap = $("#world-map");
-var width = worldmap.parent().width();
-worldmap.attr("width", width);
-worldmap.attr("height", width / ratio);
-
-$(window).on("resize", function() {
+var worldmap = $("#world-map", element);
+function on_resize() {
     var width = worldmap.parent().width();
     worldmap.attr("width", width);
     worldmap.attr("height", width/ratio);
-});
+    $(".tooltip", element).css('max-width', width/2 + "px");
+}
+$(window).on("resize", on_resize);
+on_resize();
 
 // Create JSON object
 var json = JSON.parse(AtlasJSONData);
@@ -137,8 +136,8 @@ function mousemove(d) {
         $(".tooltip", element).css("left", (d3.event.pageX + 20) + "px");
         $(".tooltip", element).css("top", (d3.event.pageY - 40) + "px");
 
-        // Compensate for tooltip overflowing view window. Round to convert to int
-        var tooltipWidth = round($(".tooltip").css("min-width").replace(/px/, ''));
+        // Compensate for tooltip overflowing view window.
+        var tooltipWidth = $(".tooltip", element).width();
         if ((d3.event.pageX + tooltipWidth + 20) > worldmap.parent().width()) {
             $(".tooltip", element).css("left", (d3.event.pageX - tooltipWidth - 20) + "px");
         }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -13,7 +13,7 @@
 .worldmap-display .tooltip {
     position: absolute;
     text-align: center;
-    min-width: 350px;
+    width: 350px;
     padding: 2px;
     font: 12px sans-serif;
     background: black;


### PR DESCRIPTION
Incorporate @mhoelter edits from #3 and some tweaks.

Here is how the map looks in a 500px viewport
![image](https://cloud.githubusercontent.com/assets/1225294/3008877/38e707f8-ded5-11e3-8a7d-9890202b2435.png)

Here is in a 850px
![image](https://cloud.githubusercontent.com/assets/1225294/3008885/608ffe22-ded5-11e3-86c7-8b7b85e15b76.png)

Also the tooltip resizes as needed.

@antoviaque 
