### PR TITLE
Show a country summary view on click on a country

### DIFF
--- a/data.json
+++ b/data.json
@@ -60,5 +60,10 @@
             "top": "A"
         }
     ],
+    "country_messages": {
+        "Côte d'Ivoire": "<div>\n    Some arbitrary text ✓\n  </div>\n  ",
+        "Italy": "<div>\n    or <code>HTML</code>\n  </div>\n",
+        "United States": "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+    },
     "survey_qualtrics_id": "SV_0pQ0bjc02t8PNDT"
 }

--- a/index.html
+++ b/index.html
@@ -12,14 +12,25 @@
 
 <body>
     <div class="worldmap-display">
-        <select class="worldmap-selector worldmap-box"></select>
-        <span class="worldmap-global worldmap-box"></span>
+        <div class="worldmap-map-view">
+            <select class="worldmap-selector worldmap-box"></select>
+            <span class="worldmap-global worldmap-box"></span>
 
-        <div class="worldmap-map">
-            <div class="tooltip">
-                <h3 class="country-name"></h3>
-                <h4 class="country-detail"></h4>
+            <div class="worldmap-map">
+                <div class="tooltip">
+                    <h3 class="country-name"></h3>
+                    <h4 class="country-detail"></h4>
+                </div>
             </div>
+        </div>
+
+        <div class="worldmap-country-view">
+            <span class="back worldmap-box">Back</span>
+            <span class="country-title worldmap-box"></span>
+
+            <div class="custom-html"></div>
+
+            <table class="country-stats"></table>
         </div>
     </div>
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -35,7 +35,7 @@
 
 .worldmap-display .worldmap-box {
     font-size: 15px;
-    font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
+    font-family: "Lucida Grande", sans-serif;
     color: white;
     padding: 14px 18px;
     border-radius: 10px;
@@ -54,4 +54,53 @@
     margin-bottom: 5px;
     background: url(arrow.png) no-repeat right 20px center;
     background-color: #428BCA;
+}
+
+.worldmap-country-view {
+    display: none;
+}
+
+.worldmap-country-view .back {
+    cursor: pointer;
+    background-color: #428BCA;
+    width: auto;
+    float: left;
+    display: block;
+    margin-right: 10px;
+}
+
+.worldmap-country-view .country-title {
+    background-color: rgb(120, 198, 121);
+    white-space: nowrap;
+    overflow: hidden;
+    width: auto;
+    max-width: 400px;
+    display: block;
+}
+
+.country-stats {
+    margin: 0 10px 10px 10px;
+    min-width: 480px;
+    border-collapse: collapse;
+}
+
+.country-stats td {
+    padding: 10px;
+    font-size: 15px;
+    font-family: "Lucida Grande", sans-serif;
+}
+
+td.stat-name {
+    font-weight: bold;
+    padding-left: 0;
+}
+td.stat-global {
+    font-size: 13px;
+    color: grey;
+}
+
+.custom-html {
+    padding: 10px;
+    font-size: 15px;
+    font-family: "Lucida Grande", sans-serif;
 }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1225294/3078341/64726fb4-e46d-11e3-9c9d-c9edeeab675d.png)

> Currently, one statistic at a time is shown upon hovering a given country. To allow to also read all a given country's statistics when necessary, allow to click to switch to a "different page", ie hiding the map through JS and showing the list of the clicked country statistics.
> 
> Allow to include arbitrarily-defined HTML at the top of the list of each country (defined in XML/JSON globally for each country). This will be used by the course team to include free text, links to edX discussion threads and wiki pages, etc.

@antoviaque 
